### PR TITLE
test(api): admin endpoint coverage, status regression, /now+/pulse contract tests

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,16 +1,20 @@
 # TASKS.md — clanka-api
-> Last updated: 2026-02-25 | Status: open
+> Last updated: 2026-02-28 | Status: open
 
 ## 🔴 High Priority
 - [x] **Deploy to Cloudflare** — live at https://clanka-api.clankamode.workers.dev (deployed 2026-02-26)
 - [x] **Write tests for `/projects` and `/tools` endpoints** — response shape, empty-state, 404 on unknown paths covered in `src/index.test.ts` (2026-02-28)
 - [x] **Wire `/projects` data to real source** — fetches from `assistant-tool-registry` via GitHub API, 1hr KV cache (2026-02-26)
+- [x] **Add POST endpoint coverage for `/set-presence`** — strict required payload validation tests for `presence`, `team`, and `activity`; empty/null payloads return 400 (2026-02-28)
+- [x] **Add POST coverage for `/heartbeat` and `/admin/activity`** — 200 success, 401 missing/invalid auth, malformed payload guardrails (2026-02-28)
+- [x] **Add regression tests for `/status` and `/status/uptime`** — online/offline threshold behavior locked around `LAST_SEEN_KEY` and `STATUS_OFFLINE_THRESHOLD_MS` (2026-02-28)
 
 ## 🟡 Medium Priority
 - [x] **Add `/tasks` endpoint** — reads `TASKS.md` from each registered repo, parses open checkboxes, returns `{ repo, tasks: [{ priority, text, done }] }[]` (completed 2026-02-28)
 - [x] **Add auth middleware tests** — test: missing auth → 401, wrong token → 401, correct token → 200
 - [x] **Add request logging** — log each request to KV list with TTL; max 100 entries rolling
 - [x] **KV TTL on presence** — if no heartbeat in 10 min, `/status` returns `{ status: "offline" }`
+- [x] **Add contract tests for `/now` and `/pulse`** — exact response shape assertions with deterministic `status`, `last_seen`, and `signal` fields (2026-02-28)
 
 ## 🟢 Low Priority / Nice to Have
 - [x] **`/changelog` endpoint** — last 10 git commits from key repos via GitHub API

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -330,7 +330,9 @@ describe("Rate limiting", () => {
   });
 });
 
-describe("Auth middleware", () => {
+describe("POST /set-presence", () => {
+  const authHeaders = { Authorization: "Bearer test-secret" };
+
   it("returns 401 when auth is missing", async () => {
     const res = await worker.fetch(req("/set-presence", "POST", {}), createEnv());
     expect(res.status).toBe(401);
@@ -344,11 +346,306 @@ describe("Auth middleware", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 200 when token is valid", async () => {
+  it("returns 400 for null or empty required fields", async () => {
+    const invalidBodies = [
+      null,
+      {},
+      { presence: "", team: { alpha: "active" }, activity: { desc: "deploy", type: "sync" } },
+      { presence: "active", team: {}, activity: { desc: "deploy", type: "sync" } },
+      { presence: "active", team: { alpha: "active" }, activity: null },
+      { presence: "active", team: { alpha: "active" }, activity: { desc: "", type: "sync" } },
+    ];
+
+    for (const body of invalidBodies) {
+      const res = await worker.fetch(req("/set-presence", "POST", body, authHeaders), createEnv());
+      const payload = await json(res);
+      expect(res.status).toBe(400);
+      expect(payload.error).toContain("required non-empty presence, team, and activity");
+    }
+  });
+
+  it("returns 200 for valid payload and updates state", async () => {
+    const now = 1_700_000_100_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+
+    const env = createEnv();
     const res = await worker.fetch(
-      req("/set-presence", "POST", {}, { Authorization: "Bearer test-secret" }),
-      createEnv(),
+      req(
+        "/set-presence",
+        "POST",
+        {
+          presence: "active",
+          team: { alpha: "active" },
+          activity: { desc: "deploying", type: "release" },
+        },
+        authHeaders,
+      ),
+      env,
     );
     expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ success: true });
+
+    const nowRes = await worker.fetch(req("/now"), env);
+    const nowBody = await json(nowRes);
+    expect(nowBody.status).toBe("active");
+    expect(nowBody.signal).toBe("⚡");
+    expect(nowBody.last_seen).toBe(new Date(now).toISOString());
+    expect(nowBody.team).toEqual({ alpha: "active" });
+    expect(nowBody.history[0]).toEqual(
+      expect.objectContaining({
+        desc: "deploying",
+        type: "release",
+      }),
+    );
+  });
+});
+
+describe("POST /heartbeat", () => {
+  const authHeaders = { Authorization: "Bearer test-secret" };
+
+  it("returns 401 when auth is missing", async () => {
+    const res = await worker.fetch(req("/heartbeat", "POST", {}), createEnv());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when token is invalid", async () => {
+    const res = await worker.fetch(
+      req("/heartbeat", "POST", {}, { Authorization: "Bearer wrong-token" }),
+      createEnv(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when history is not an array", async () => {
+    const res = await worker.fetch(
+      req("/heartbeat", "POST", { history: { bad: true } }, authHeaders),
+      createEnv(),
+    );
+    const body = await json(res);
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error: "Invalid body: history must be an array" });
+  });
+
+  it("returns 200 and updates online status/history", async () => {
+    const now = 1_700_000_200_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+
+    const env = createEnv();
+    const res = await worker.fetch(
+      req(
+        "/heartbeat",
+        "POST",
+        {
+          history: [{ timestamp: now - 1_000, desc: "prior", type: "heartbeat", hash: "h1" }],
+          activity: { desc: "beat", type: "heartbeat" },
+        },
+        authHeaders,
+      ),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ success: true, timestamp: now });
+
+    const statusRes = await worker.fetch(req("/status"), env);
+    const statusBody = await json(statusRes);
+    expect(statusBody.status).toBe("operational");
+    expect(statusBody.last_seen).toBe(new Date(now).toISOString());
+
+    const historyRes = await worker.fetch(req("/history"), env);
+    const historyBody = await json(historyRes);
+    expect(historyBody.history[0]).toEqual(
+      expect.objectContaining({
+        desc: "beat",
+        type: "heartbeat",
+      }),
+    );
+  });
+});
+
+describe("POST /admin/activity", () => {
+  const authHeaders = { Authorization: "Bearer test-secret" };
+
+  it("returns 401 when auth is missing", async () => {
+    const res = await worker.fetch(req("/admin/activity", "POST", { desc: "x", type: "event" }), createEnv());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when token is invalid", async () => {
+    const res = await worker.fetch(
+      req("/admin/activity", "POST", { desc: "x", type: "event" }, { Authorization: "Bearer wrong-token" }),
+      createEnv(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for malformed payload", async () => {
+    const res = await worker.fetch(req("/admin/activity", "POST", [], authHeaders), createEnv());
+    const body = await json(res);
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error: "Invalid body" });
+  });
+
+  it("returns 200 and writes entry to history", async () => {
+    const env = createEnv();
+    const res = await worker.fetch(
+      req("/admin/activity", "POST", { desc: "manual update", type: "ops" }, authHeaders),
+      env,
+    );
+    const payload = await json(res);
+    expect(res.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(payload.entry).toEqual(
+      expect.objectContaining({
+        desc: "manual update",
+        type: "ops",
+      }),
+    );
+
+    const historyRes = await worker.fetch(req("/history"), env);
+    const historyBody = await json(historyRes);
+    expect(historyBody.history[0]).toEqual(
+      expect.objectContaining({
+        desc: "manual update",
+        type: "ops",
+      }),
+    );
+  });
+});
+
+describe("Status regression around last_seen threshold", () => {
+  const THRESHOLD_MS = 10 * 60 * 1000;
+
+  it("returns offline when LAST_SEEN_KEY is missing", async () => {
+    const now = 1_700_000_300_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const env = createEnv();
+
+    const statusRes = await worker.fetch(req("/status"), env);
+    const statusBody = await json(statusRes);
+    expect(statusBody).toEqual({ status: "offline" });
+
+    const uptimeRes = await worker.fetch(req("/status/uptime"), env);
+    const uptimeBody = await json(uptimeRes);
+    expect(uptimeBody).toEqual({ status: "offline", uptime_ms: 0 });
+  });
+
+  it("returns operational exactly at STATUS_OFFLINE_THRESHOLD_MS boundary", async () => {
+    const now = 1_700_000_400_000;
+    const lastSeen = now - THRESHOLD_MS;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const env = createEnv({
+      last_seen: String(lastSeen),
+      started: String(now - 12_345),
+    });
+
+    const statusRes = await worker.fetch(req("/status"), env);
+    const statusBody = await json(statusRes);
+    expect(statusBody.status).toBe("operational");
+    expect(statusBody.last_seen).toBe(new Date(lastSeen).toISOString());
+    expect(statusBody.signal).toBe("⚡");
+
+    const uptimeRes = await worker.fetch(req("/status/uptime"), env);
+    const uptimeBody = await json(uptimeRes);
+    expect(uptimeBody).toEqual(
+      expect.objectContaining({
+        status: "operational",
+        signal: "⚡",
+        last_seen: new Date(lastSeen).toISOString(),
+        uptime_ms: 12_345,
+      }),
+    );
+  });
+
+  it("returns offline when last_seen is older than threshold", async () => {
+    const now = 1_700_000_500_000;
+    const lastSeen = now - THRESHOLD_MS - 1;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const env = createEnv({
+      last_seen: String(lastSeen),
+      started: String(now - 8_000),
+    });
+
+    const statusRes = await worker.fetch(req("/status"), env);
+    const statusBody = await json(statusRes);
+    expect(statusBody).toEqual({ status: "offline" });
+
+    const uptimeRes = await worker.fetch(req("/status/uptime"), env);
+    const uptimeBody = await json(uptimeRes);
+    expect(uptimeBody).toEqual({ status: "offline", uptime_ms: 8_000 });
+  });
+});
+
+describe("Contracts: /now and /pulse", () => {
+  it("GET /now returns exact shape with status, last_seen, signal", async () => {
+    const now = 1_700_000_600_000;
+    const lastSeen = now - 5_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const env = createEnv({
+      presence: JSON.stringify({ state: "focus", message: "shipping tests", timestamp: lastSeen }),
+      history: JSON.stringify([{ timestamp: lastSeen - 1_000, desc: "coverage added", type: "test", hash: "abc12345" }]),
+      team: JSON.stringify({ alpha: "active", beta: { status: "active" }, gamma: "idle" }),
+      started: String(now - 60_000),
+      last_seen: String(lastSeen),
+    });
+
+    const res = await worker.fetch(req("/now"), env);
+    expect(res.status).toBe(200);
+    const body = await json(res);
+
+    expect(Object.keys(body).sort()).toEqual([
+      "agents_active",
+      "current",
+      "history",
+      "last_seen",
+      "signal",
+      "stack",
+      "status",
+      "team",
+      "timestamp",
+      "uptime",
+    ]);
+    expect(body).toEqual({
+      current: "shipping tests",
+      status: "focus",
+      signal: "⚡",
+      stack: ["Cloudflare Workers", "TypeScript", "Lit"],
+      timestamp: lastSeen,
+      uptime: 60_000,
+      agents_active: 2,
+      last_seen: new Date(lastSeen).toISOString(),
+      history: [{ timestamp: lastSeen - 1_000, desc: "coverage added", type: "test", hash: "abc12345" }],
+      team: { alpha: "active", beta: { status: "active" }, gamma: "idle" },
+    });
+  });
+
+  it("GET /pulse returns exact shape with status, last_seen, signal", async () => {
+    const lastSeen = 1_700_000_700_000;
+    const env = createEnv({
+      presence: JSON.stringify({ state: "focus", message: "shipping tests", timestamp: lastSeen }),
+      history: JSON.stringify([{ timestamp: lastSeen - 1_000, desc: "coverage added", type: "test", hash: "abc12345" }]),
+      team: JSON.stringify({ alpha: "active", beta: { status: "active" }, gamma: "idle" }),
+      last_seen: String(lastSeen),
+    });
+
+    const res = await worker.fetch(req("/pulse"), env);
+    expect(res.status).toBe(200);
+    const body = await json(res);
+
+    expect(Object.keys(body).sort()).toEqual([
+      "agents_active",
+      "last_event_desc",
+      "last_seen",
+      "signal",
+      "status",
+      "ts",
+    ]);
+    expect(body).toEqual({
+      ts: expect.any(String),
+      status: "focus",
+      signal: "⚡",
+      last_seen: new Date(lastSeen).toISOString(),
+      agents_active: 2,
+      last_event_desc: "coverage added",
+    });
   });
 });


### PR DESCRIPTION
42 tests passing. Covers: /set-presence POST validation, /heartbeat + /admin/activity auth + payload guards, /status + /status/uptime online/offline regression, /now + /pulse contract shape tests.