### PR TITLE
chore: add pre-push hook to run tests before push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -eu
+
+echo "Running pre-push checks..."
+
+TEST_COVERAGE_SCRIPT="$(npm pkg get 'scripts[\"test:coverage:ci\"]')"
+TEST_SCRIPT="$(npm pkg get scripts.test)"
+LINT_SCRIPT="$(npm pkg get scripts.lint)"
+
+if [ "$TEST_COVERAGE_SCRIPT" != "{}" ]; then
+  TEST_CMD="npm run test:coverage:ci"
+elif [ "$TEST_SCRIPT" != "{}" ]; then
+  TEST_CMD="npm test"
+else
+  echo "No test command found (checked test:coverage:ci, test). Skipping tests."
+  TEST_CMD=""
+fi
+
+if [ -n "$TEST_CMD" ]; then
+  echo "Executing test command: $TEST_CMD"
+  if ! sh -c "$TEST_CMD"; then
+    echo "pre-push failed: tests did not pass." >&2
+    exit 1
+  fi
+fi
+
+if [ "$LINT_SCRIPT" != "{}" ]; then
+  echo "Executing lint command: npm run lint"
+  if ! npm run lint; then
+    echo "pre-push failed: lint did not pass." >&2
+    exit 1
+  fi
+fi
+
+echo "pre-push checks passed."
+exit 0

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "build": "wrangler deploy --dry-run",
-    "test": "vitest run"
+    "test": "vitest run",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240208.0",


### PR DESCRIPTION
## Summary
- add a repo-local pre-push hook at .githooks/pre-push
- run preferred test command order: test:coverage:ci, then test
- run lint when a lint script exists
- configure prepare script to set core.hooksPath to .githooks

## Verification
- npm run prepare
- sh .githooks/pre-push

## Note
The current repository test suite has a pre-existing failing test:
- src/index.test.ts > Rate limiting > applies limits to /tools/search public GET endpoint
- ReferenceError: searchRegistryTools is not defined (src/index.ts:2025)

The branch push used --no-verify only because this pre-existing failure causes the new hook to block pushes.