### PR TITLE
fix(status): honest endpoint discovery + OpenAPI /status contract

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -47,16 +47,28 @@ export const RATE_LIMIT_WINDOW_MS = RATE_LIMIT_WINDOW_SEC * 1000;
 export const RATE_LIMIT_MAX_REQUESTS = 10;
 export const METRICS_KEY = "metrics:v1";
 export const API_VERSION = "1.0.0";
+/** Public-facing discovery list for GET /status. Only include routes that exist. */
 export const STATUS_ENDPOINTS = [
-  "/",
-  "/fleet/summary",
+  "/changelog",
   "/fleet/health",
   "/fleet/score",
+  "/fleet/summary",
+  "/fleet/trend",
+  "/github/events",
+  "/github/stats",
+  "/health",
   "/history",
-  "/now",
-  "/status",
-  "/tools/search",
   "/metrics",
+  "/now",
+  "/openapi.json",
+  "/posts/count",
+  "/projects",
+  "/pulse",
+  "/status",
+  "/status/uptime",
+  "/tasks",
+  "/tools",
+  "/tools/search",
 ];
 export const startTime = Date.now();
 
@@ -80,21 +92,26 @@ export const OPENAPI_SPEC = {
   paths: {
     "/status": {
       get: {
-        summary: "Get service status",
+        summary: "Get service status contract and endpoint discovery list",
         responses: {
           "200": {
-            description: "Current status payload",
+            description: "Public status contract (ok/version/endpoints). Liveness is on /health and /status/uptime.",
             content: {
               "application/json": {
                 schema: {
                   type: "object",
                   properties: {
-                    status: { type: "string" },
-                    timestamp: { type: "string" },
-                    signal: { type: "string" },
-                    last_seen: { type: "string" },
+                    ok: { type: "boolean" },
+                    version: { type: "string" },
+                    timestamp: { type: "string", format: "date-time" },
+                    endpoints: {
+                      type: "array",
+                      items: { type: "string" },
+                      description: "Routable paths exposed by this worker (excludes unmapped paths like /)",
+                    },
                   },
-                  additionalProperties: true,
+                  required: ["ok", "version", "timestamp", "endpoints"],
+                  additionalProperties: false,
                 },
               },
             },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -13,15 +13,26 @@ const VALID_SET_PRESENCE_PAYLOAD = {
   activity: { type: "SYNC", desc: "presence updated" },
 };
 const STATUS_ENDPOINTS = [
-  "/",
-  "/fleet/summary",
+  "/changelog",
   "/fleet/health",
   "/fleet/score",
+  "/fleet/summary",
+  "/fleet/trend",
+  "/github/events",
+  "/github/stats",
+  "/health",
   "/history",
-  "/now",
-  "/status",
-  "/tools/search",
   "/metrics",
+  "/now",
+  "/openapi.json",
+  "/posts/count",
+  "/projects",
+  "/pulse",
+  "/status",
+  "/status/uptime",
+  "/tasks",
+  "/tools",
+  "/tools/search",
 ];
 
 function createMockKV(store: Record<string, string> = {}): any {
@@ -2120,6 +2131,30 @@ describe("GET /status", () => {
     const body = await json(res);
     expect(body.endpoints).toContain("/status");
     expect(body.endpoints).toContain("/metrics");
+  });
+
+  it("does not advertise unmapped root path as an endpoint", async () => {
+    const res = await worker.fetch(req("/status"), createEnv());
+    const body = await json(res);
+    expect(body.endpoints).not.toContain("/");
+    expect(body.endpoints).toContain("/health");
+    expect(body.endpoints).toContain("/pulse");
+  });
+});
+
+describe("OpenAPI /status contract honesty", () => {
+  it("documents ok/version/endpoints instead of the /health liveness shape", async () => {
+    const res = await worker.fetch(req("/openapi.json"), createEnv());
+    const body = await json(res);
+    const schema = body.paths?.["/status"]?.get?.responses?.["200"]?.content?.["application/json"]?.schema;
+    expect(schema?.properties?.ok).toBeTruthy();
+    expect(schema?.properties?.version).toBeTruthy();
+    expect(schema?.properties?.endpoints).toBeTruthy();
+    expect(schema?.properties?.status).toBeUndefined();
+    expect(schema?.properties?.signal).toBeUndefined();
+    expect(schema?.required).toEqual(
+      expect.arrayContaining(["ok", "version", "timestamp", "endpoints"]),
+    );
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent
Stop advertising routes that do not exist, and make `/openapi.json` describe the real `/status` contract.

## Problem
- `GET /status` listed `/` in `endpoints` even though root returns 404.
- Discovery omitted many live public routes (`/health`, `/pulse`, `/projects`, etc.).
- OpenAPI documented `/status` as a liveness payload (`status`/`signal`/`last_seen`), which is what `/health` returns — clients reading the spec get the wrong shape (`ok`/`version`/`endpoints`).

## Change
- Replace `STATUS_ENDPOINTS` with the routable public surface (still includes `/metrics` for operator discovery).
- Align OpenAPI `/status` schema with the runtime contract.
- Add regression tests for “no `/`” and OpenAPI property honesty.

## Test plan
- [x] `npm test` (203 passing)
- [ ] `GET /status` → endpoints exclude `/`, include `/health` and `/pulse`
- [ ] `GET /openapi.json` → `/status` schema has `ok`/`version`/`endpoints`, not `signal`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae249947-51d6-475b-b125-167c66b456aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae249947-51d6-475b-b125-167c66b456aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

