### PR TITLE
fix(github): don't disguise fetch failures as empty stats/posts

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -14,12 +14,18 @@ import type { ChangelogEntry, Env, GithubEvent, GithubStatsPayload, PostsCountPa
 
 const POST_HTML_RE = /^(\d{4}-\d{2}-\d{2})-(.+)\.html$/;
 
-function emptyPostsCount(): PostsCountPayload {
-  return {
+function emptyPostsCount(error?: string): PostsCountPayload {
+  const base: PostsCountPayload = {
     count: 0,
     lastPost: "000",
     lastPostDate: "",
     lastPostSlug: "",
+  };
+  if (!error) return base;
+  return {
+    ...base,
+    available: false,
+    error,
   };
 }
 
@@ -63,12 +69,12 @@ export async function loadPostsCount(env: Env): Promise<PostsCountPayload> {
   try {
     const res = await fetch(BLOG_POSTS_LIST_URL, { headers });
     if (!res.ok) {
-      return emptyPostsCount();
+      return emptyPostsCount("github_unavailable");
     }
 
     const body = await res.json() as unknown;
     if (!Array.isArray(body)) {
-      return emptyPostsCount();
+      return emptyPostsCount("github_unavailable");
     }
 
     const names: string[] = [];
@@ -98,9 +104,12 @@ export async function loadPostsCount(env: Env): Promise<PostsCountPayload> {
     } catch {
       // ignore cache write failures
     }
-    return payload;
+    return {
+      ...payload,
+      available: true,
+    };
   } catch {
-    return emptyPostsCount();
+    return emptyPostsCount("github_unavailable");
   }
 }
 
@@ -216,6 +225,18 @@ export async function loadGithubStats(env: Env): Promise<GithubStatsPayload> {
       fetch("https://api.github.com/users/clankamode/repos?per_page=100&type=owner", { headers: ghHeaders }),
     ]);
 
+    if (!userRes.ok && !reposRes.ok) {
+      return {
+        repoCount: 0,
+        totalStars: 0,
+        lastPushedAt: null,
+        lastPushedRepo: null,
+        cachedAt: new Date().toISOString(),
+        available: false,
+        error: "github_unavailable",
+      };
+    }
+
     type GhRepo = { stargazers_count: number; pushed_at: string; name: string };
     const repos: GhRepo[] = reposRes.ok ? (await reposRes.json() as GhRepo[]) : [];
 
@@ -244,6 +265,7 @@ export async function loadGithubStats(env: Env): Promise<GithubStatsPayload> {
       lastPushedAt,
       lastPushedRepo,
       cachedAt: new Date().toISOString(),
+      available: true,
     };
 
     try {
@@ -259,6 +281,8 @@ export async function loadGithubStats(env: Env): Promise<GithubStatsPayload> {
       lastPushedAt: null,
       lastPushedRepo: null,
       cachedAt: new Date().toISOString(),
+      available: false,
+      error: "github_unavailable",
     };
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -561,6 +561,8 @@ describe("Malformed cache fallbacks", () => {
       lastPushedAt: null,
       lastPushedRepo: null,
       cachedAt: expect.any(String),
+      available: false,
+      error: "github_unavailable",
     }));
     expect(Number.isNaN(Date.parse(body.cachedAt))).toBe(false);
   });
@@ -639,7 +641,9 @@ describe("GET /github/stats", () => {
       lastPushedAt: "2026-03-02T00:00:00.000Z",
       lastPushedRepo: "beta",
       cachedAt: expect.any(String),
+      available: true,
     }));
+    expect(body).not.toHaveProperty("error");
     expect(putCalls).toEqual(expect.arrayContaining([
       expect.objectContaining({
         key: "github:stats:v1",
@@ -661,7 +665,21 @@ describe("GET /github/stats", () => {
       lastPushedAt: null,
       lastPushedRepo: null,
       cachedAt: expect.any(String),
+      available: false,
+      error: "github_unavailable",
     }));
+  });
+
+  it("marks stats unavailable when both GitHub endpoints return errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
+
+    const res = await worker.fetch(req("/github/stats"), createEnv());
+    const body = await json(res);
+
+    expect(res.status).toBe(200);
+    expect(body.available).toBe(false);
+    expect(body.error).toBe("github_unavailable");
+    expect(body.repoCount).toBe(0);
   });
 
   it("returns live stats even when caching the payload fails", async () => {
@@ -692,6 +710,7 @@ describe("GET /github/stats", () => {
       totalStars: 3,
       lastPushedAt: "2026-03-03T00:00:00.000Z",
       lastPushedRepo: "clanka-api",
+      available: true,
     }));
   });
 
@@ -2577,8 +2596,26 @@ describe("GET /posts/count", () => {
       lastPost: "002",
       lastPostDate: "2026-04-09",
       lastPostSlug: "the-telemetry-trap",
+      available: true,
     });
     fetchSpy.mockRestore();
+  });
+
+  it("marks posts unavailable instead of looking like zero posts when GitHub fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
+
+    const res = await worker.fetch(req("/posts/count"), createEnv());
+    const body = await json(res);
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      count: 0,
+      lastPost: "000",
+      lastPostDate: "",
+      lastPostSlug: "",
+      available: false,
+      error: "github_unavailable",
+    });
   });
 
   it("rejects non-GET with 405", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,9 @@ export type GithubStatsPayload = {
   lastPushedAt: string | null;
   lastPushedRepo: string | null;
   cachedAt: string;
+  /** False when the payload is a failure placeholder, not a real empty org. */
+  available?: boolean;
+  error?: string;
 };
 
 export type GithubEvent = {
@@ -109,4 +112,7 @@ export type PostsCountPayload = {
   lastPost: string;
   lastPostDate: string;
   lastPostSlug: string;
+  /** False when the payload is a failure placeholder, not a real empty posts dir. */
+  available?: boolean;
+  error?: string;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent
Stop empty-looking success payloads when GitHub is down.

## Problem
- `/github/stats` returned `{ repoCount: 0, totalStars: 0, ... }` on network/API failure — indistinguishable from a real empty org.
- `/posts/count` returned `{ count: 0, lastPost: "000", ... }` on failure — looks like “no posts” to the public site.

## Change
- On failure: `available: false`, `error: "github_unavailable"`.
- On success: `available: true` (including a genuine zero-count posts dir).
- Treat dual GitHub endpoint failures on stats as unavailable, not empty.

## Test plan
- [x] `npm test` (203 passing)
- [ ] Force stats/posts fetch failure locally → body includes `available: false`
- [ ] Successful fetch → `available: true`, no `error`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae249947-51d6-475b-b125-167c66b456aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae249947-51d6-475b-b125-167c66b456aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

