### PR TITLE
fix(projects): don't imply registry members are actively running

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -187,6 +187,8 @@ describe("GET /projects", () => {
       expect(p).toHaveProperty("url");
       expect(p).toHaveProperty("status");
       expect(p).toHaveProperty("last_updated");
+      expect(p.status).toBe("registered");
+      expect(p.status).not.toBe("active");
     }
   });
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -204,7 +204,8 @@ export function registryEntriesToProjects(entries: RegistryEntry[]): Project[] {
       name: e.repo.replace("clankamode/", ""),
       description: e.description ?? `${e.tier} — ${e.criticality} criticality`,
       url: `https://github.com/${e.repo}`,
-      status: "active",
+      // Registry membership ≠ runtime liveness; do not advertise "active".
+      status: "registered",
       last_updated: today,
     }));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent
Stop `/projects` from looking like a live health feed.

## Problem
Every project derived from the tool registry was hard-coded `status: "active"`, even though registry membership says nothing about heartbeat, deploy health, or whether the tool is running.

## Change
- Emit `status: "registered"` from `registryEntriesToProjects`.
- Lock the contract with a test so we don’t regress back to fake “active”.

## Test plan
- [x] `npm test`
- [ ] `GET /projects` → each project `status` is `registered`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae249947-51d6-475b-b125-167c66b456aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae249947-51d6-475b-b125-167c66b456aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

