### PR TITLE
fix(presence): don't invent online/active without a heartbeat

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2015,16 +2015,55 @@ describe("GET /now and GET /pulse contracts", () => {
     expect(body.signal).toBe("⚡");
   });
 
+  it("returns offline in /now when heartbeat was never recorded", async () => {
+    const now = 1_750_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+
+    const res = await worker.fetch(req("/now"), createEnv());
+    const body = await json(res);
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("offline");
+    expect(body.last_seen).toBeNull();
+    expect(body.timestamp).toBeNull();
+    expect(body.current).toBe("offline");
+    expect(body.uptime).toBe(0);
+  });
+
+  it("does not invent epoch-sized uptime when started is zero", async () => {
+    const now = 1_750_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+
+    const res = await worker.fetch(
+      req("/now"),
+      createEnv({
+        started: "0",
+        last_seen: String(now - 1_000),
+        presence: JSON.stringify({ state: "active", message: "shipping", timestamp: now - 1_000 }),
+      }),
+    );
+    const body = await json(res);
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("active");
+    expect(body.uptime).toBe(0);
+    expect(body.uptime).toBeLessThan(60_000);
+  });
+
   it("rejects non-GET /now with 405", async () => {
     const res = await worker.fetch(req("/now", "POST"), createEnv());
     expect(res.status).toBe(405);
   });
 
   it("returns deterministic /pulse payload shape", async () => {
+    const now = 1_750_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+
     const res = await worker.fetch(
       req("/pulse"),
       createEnv({
-        presence: JSON.stringify({ state: "active" }),
+        last_seen: String(now - 1_000),
+        presence: JSON.stringify({ state: "active", timestamp: now - 1_000 }),
         team: JSON.stringify({ clanka: { status: "active" }, helper: { status: "idle" } }),
         history: JSON.stringify([{ type: "SYNC", desc: "deployed", timestamp: 12345, hash: "aaa" }]),
       }),
@@ -2038,6 +2077,15 @@ describe("GET /now and GET /pulse contracts", () => {
       agents_active: 1,
       last_event_desc: "deployed",
     }));
+  });
+
+  it("returns offline in /pulse when presence and heartbeat are missing", async () => {
+    const res = await worker.fetch(req("/pulse"), createEnv());
+    const body = await json(res);
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("offline");
+    expect(body.status).not.toBe("active");
   });
 });
 

--- a/src/presence.ts
+++ b/src/presence.ts
@@ -1,10 +1,45 @@
 import { HISTORY_LIMIT, STATUS_OFFLINE_THRESHOLD_MS } from "./config";
 import type { HistoryEntry } from "./types";
 
+/** Parse a positive epoch-ms timestamp; reject missing/zero/invalid values. */
+export function parsePositiveEpochMs(raw: string | null | undefined): number | null {
+  if (typeof raw !== "string" || raw.trim().length === 0) return null;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return value;
+}
+
+/**
+ * Resolve last-seen from heartbeat KV and optional presence.timestamp.
+ * Returns null when we have no trustworthy signal (do not invent "now").
+ */
+export function resolveLastSeenMs(
+  lastSeenRaw: string | null,
+  presenceTimestamp?: number | null,
+): number | null {
+  const fromHeartbeat = parsePositiveEpochMs(lastSeenRaw);
+  if (fromHeartbeat !== null) return fromHeartbeat;
+  if (typeof presenceTimestamp === "number" && Number.isFinite(presenceTimestamp) && presenceTimestamp > 0) {
+    return presenceTimestamp;
+  }
+  return null;
+}
+
+export function isOfflineFromLastSeen(lastSeenMs: number | null, now = Date.now()): boolean {
+  if (lastSeenMs === null) return true;
+  return now - lastSeenMs > STATUS_OFFLINE_THRESHOLD_MS;
+}
+
+/** Treat missing/zero started as "start now" so uptime is not epoch-sized. */
+export function resolveStartedMs(startedRaw: string | null, now = Date.now()): number {
+  const started = parsePositiveEpochMs(startedRaw);
+  return started ?? now;
+}
+
 export function getStatusPayload(lastSeenRaw: string | null) {
-  const lastSeen = typeof lastSeenRaw === "string" ? Number(lastSeenRaw) : NaN;
+  const lastSeen = parsePositiveEpochMs(lastSeenRaw);
   const now = Date.now();
-  if (!Number.isFinite(lastSeen) || now - lastSeen > STATUS_OFFLINE_THRESHOLD_MS) {
+  if (lastSeen === null || now - lastSeen > STATUS_OFFLINE_THRESHOLD_MS) {
     return { status: "offline" };
   }
 
@@ -17,9 +52,9 @@ export function getStatusPayload(lastSeenRaw: string | null) {
 }
 
 export function getStatusUptimePayload(lastSeenRaw: string | null) {
-  const lastSeen = typeof lastSeenRaw === "string" ? Number(lastSeenRaw) : NaN;
+  const lastSeen = parsePositiveEpochMs(lastSeenRaw);
   const now = Date.now();
-  if (!Number.isFinite(lastSeen) || now - lastSeen > STATUS_OFFLINE_THRESHOLD_MS) {
+  if (lastSeen === null || now - lastSeen > STATUS_OFFLINE_THRESHOLD_MS) {
     return {
       status: "offline",
       uptime_ms: 0,

--- a/src/router.ts
+++ b/src/router.ts
@@ -5,7 +5,6 @@ import {
   LAST_SEEN_KEY,
   OPENAPI_SPEC,
   STATUS_ENDPOINTS,
-  STATUS_OFFLINE_THRESHOLD_MS,
   startTime,
 } from "./config";
 import {
@@ -41,7 +40,11 @@ import {
   countActiveAgents,
   getStatusPayload,
   getStatusUptimePayload,
+  isOfflineFromLastSeen,
   normalizeHistory,
+  parsePositiveEpochMs,
+  resolveLastSeenMs,
+  resolveStartedMs,
   toHistoryEntry,
 } from "./presence";
 
@@ -488,20 +491,28 @@ export async function handleFetch(
         });
       }
 
-      const [presenceRaw, historyRaw, teamRaw] = await Promise.all([
+      const [presenceRaw, historyRaw, teamRaw, lastSeenRaw] = await Promise.all([
         env.CLANKA_STATE.get("presence"),
         env.CLANKA_STATE.get("history"),
         env.CLANKA_STATE.get("team"),
+        env.CLANKA_STATE.get(LAST_SEEN_KEY),
       ]);
       const presence = safeParseJSON<{ state?: string; timestamp?: number } | null>(presenceRaw, null);
       const history = normalizeHistory(safeParseJSON<unknown[]>(historyRaw || "[]", []));
       const team = safeParseJSON<unknown>(teamRaw || "{}", {});
       const agentsActive = countActiveAgents(team);
+      const lastSeenMs = resolveLastSeenMs(lastSeenRaw, presence?.timestamp);
+      const offline = isOfflineFromLastSeen(lastSeenMs);
+      const status = offline
+        ? "offline"
+        : (typeof presence?.state === "string" && presence.state.trim()
+          ? presence.state.trim()
+          : "unknown");
 
       return respond(
         JSON.stringify({
           ts: new Date().toISOString(),
-          status: presence?.state || "active",
+          status,
           agents_active: agentsActive,
           last_event_desc: history[0]?.desc || null,
         }),
@@ -746,30 +757,35 @@ export async function handleFetch(
       const presence = safeParseJSON<{ state?: string; message?: string; timestamp?: number } | null>(presenceRaw, null);
       const history = normalizeHistory(safeParseJSON<unknown[]>(historyRaw || "[]", []));
       const team = safeParseJSON<unknown>(teamRaw || "{}", {});
-      let started = Number(startedRaw);
-      if (!Number.isFinite(started)) {
-        started = now;
+      const started = resolveStartedMs(startedRaw, now);
+      if (parsePositiveEpochMs(startedRaw) === null) {
         await env.CLANKA_STATE.put("started", String(started));
       }
       const agentsActive = countActiveAgents(team);
-      const lastSeenFromPresence = typeof presence?.timestamp === "number" ? presence.timestamp : NaN;
-      const lastSeenFromHeartbeat = typeof lastSeenRaw === "string" ? Number(lastSeenRaw) : NaN;
-      const lastSeenMs = Number.isFinite(lastSeenFromHeartbeat)
-        ? lastSeenFromHeartbeat
-        : Number.isFinite(lastSeenFromPresence)
-          ? lastSeenFromPresence
-          : now;
-      const isOffline = now - lastSeenMs > STATUS_OFFLINE_THRESHOLD_MS;
+      const lastSeenMs = resolveLastSeenMs(lastSeenRaw, presence?.timestamp);
+      const offline = isOfflineFromLastSeen(lastSeenMs, now);
+      const status = offline
+        ? "offline"
+        : (typeof presence?.state === "string" && presence.state.trim()
+          ? presence.state.trim()
+          : "unknown");
+      const current = offline
+        ? (typeof presence?.message === "string" && presence.message.trim()
+          ? presence.message
+          : "offline")
+        : (typeof presence?.message === "string" && presence.message.trim()
+          ? presence.message
+          : "online");
 
       return respond(JSON.stringify({
-        current: presence?.message || "monitoring workspace and building public signals",
-        status: isOffline ? "offline" : (presence?.state || "active"),
+        current,
+        status,
         signal: "⚡",
         stack: ["Cloudflare Workers", "TypeScript", "Lit"],
         timestamp: lastSeenMs,
         uptime: Math.max(0, now - started),
         agents_active: agentsActive,
-        last_seen: new Date(lastSeenMs).toISOString(),
+        last_seen: lastSeenMs === null ? null : new Date(lastSeenMs).toISOString(),
         history,
         team,
       }), { headers: corsHeaders });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent
Make `/now` and `/pulse` honest when there is no fresh heartbeat.

## Problem
- Missing `last_seen` was treated as “just now”, so `/now` looked online with a marketing default message.
- `/pulse` defaulted `status` to `"active"` whenever presence KV was empty.
- `started: "0"` produced epoch-sized `uptime` that looked like years of continuous operation.

## Change
- Shared helpers in `presence.ts` reject missing/zero timestamps.
- `/now` and `/pulse` report `offline` without a trustworthy heartbeat; no fabricated `last_seen`.
- Zero/invalid `started` resets to now so uptime stays near zero until a real start is recorded.
- Regression tests for missing heartbeat, zero started, and `/pulse` offline default.

## Test plan
- [x] `npm test` (204 passing)
- [ ] Empty KV → `GET /now` and `GET /pulse` return `status: "offline"`
- [ ] Fresh `last_seen` + presence → still `active`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae249947-51d6-475b-b125-167c66b456aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae249947-51d6-475b-b125-167c66b456aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

