### PR TITLE
fix: honest changelog/events on GitHub failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Edge control API behind Clanka's public presence surface and fleet metadata. Run
 | `/tools/:repo` | None | `GET` | `200` | `404`, `405`, `429` | Single registry tool by repo name. |
 | `/projects` | None | `GET` | `200` | `405`, `429` | Core/critical registry projects. |
 | `/tasks` | None | `GET` | `200` | `405`, `429` | Parsed open checkboxes from each repo `TASKS.md`. |
-| `/changelog` | None | `GET` | `200` | `405`, `429` | Commits from `meta-runner`; empty + `error: "no token"` without `GITHUB_TOKEN`. |
+| `/changelog` | None | `GET` | `200` | `405`, `429` | Commits from `meta-runner`; `available: false` + `error` when token missing or GitHub unreachable. |
 | `/fleet/summary` | None | `GET` | `200` | `405`, `429` | Fleet grouping by tier and criticality from registry data. |
 | `/fleet/health` | None | `GET` | `200` | `503`, `405`, `429` | Fleet CI health from cache/GitHub (503 when unavailable and uncached). |
 | `/fleet/score` | None | `GET` | `200` | `405`, `429` | Aggregate fleet health score. |
 | `/fleet/trend` | None | `GET` | `200` | `405`, `429` | Per-repo CI conclusion trend. |
 | `/history` | None | `GET` | `200` | `405`, `429` | Activity history, supports `?limit=` (max 20), returns `{ history, count }`. |
-| `/github/stats` | None | `GET` | `200` | `405`, `429` | Org repo/star aggregates (may include `error` when GitHub is unreachable). |
-| `/github/events` | None | `GET` | `200` | `405`, `429` | Recent public GitHub events. |
+| `/github/stats` | None | `GET` | `200` | `405`, `429` | Org repo/star aggregates (`available: false` when GitHub is unreachable). |
+| `/github/events` | None | `GET` | `200` | `405`, `429` | Recent public GitHub events (`available: false` when GitHub is unreachable). |
 | `/posts/count` | None | `GET` | `200` | `405`, `429` | Blog post count from `clankamode.github.io` posts dir. |
 | `/openapi.json` | None | `GET` | `200` | `405`, `429` | OpenAPI 3 document for documented routes. |
 | `/metrics` | `X-Admin-Token: <ADMIN_TOKEN>` | `GET` | `200` | `401`, `503`, `405` | Admin metrics; no-store. Uses `ADMIN_TOKEN`, not Bearer. |

--- a/src/config.ts
+++ b/src/config.ts
@@ -162,7 +162,7 @@ export const OPENAPI_SPEC = {
     },
     "/projects": {
       get: {
-        summary: "Get active projects from registry",
+        summary: "Get registered projects from registry",
         responses: {
           "200": {
             description: "Projects payload",
@@ -430,6 +430,7 @@ export const OPENAPI_SPEC = {
                       },
                     },
                     timestamp: { type: "string" },
+                    available: { type: "boolean" },
                     error: { type: "string" },
                   },
                   required: ["commits", "timestamp"],

--- a/src/github-events.test.ts
+++ b/src/github-events.test.ts
@@ -26,11 +26,11 @@ describe("loadGithubEvents", () => {
       },
     ];
 
-    const events = await loadGithubEvents(createMockKV({
+    const payload = await loadGithubEvents(createMockKV({
       "github:events:v1": JSON.stringify(cached),
     }));
 
-    expect(events).toEqual(cached);
+    expect(payload).toEqual({ events: cached, available: true });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -44,7 +44,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV({
+    const { events } = await loadGithubEvents(createMockKV({
       "github:events:v1": "{invalid-json",
     }));
 
@@ -53,20 +53,28 @@ describe("loadGithubEvents", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("returns [] when GitHub response is non-ok", async () => {
+  it("marks events unavailable when GitHub response is non-ok", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const payload = await loadGithubEvents(createMockKV());
 
-    expect(events).toEqual([]);
+    expect(payload).toEqual({
+      events: [],
+      available: false,
+      error: "github_unavailable",
+    });
   });
 
-  it("returns [] when the GitHub request throws", async () => {
+  it("marks events unavailable when the GitHub request throws", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
 
-    const events = await loadGithubEvents(createMockKV());
+    const payload = await loadGithubEvents(createMockKV());
 
-    expect(events).toEqual([]);
+    expect(payload).toEqual({
+      events: [],
+      available: false,
+      error: "github_unavailable",
+    });
   });
 
   it("returns fetched events even when writing the cache fails", async () => {
@@ -84,16 +92,19 @@ describe("loadGithubEvents", () => {
       put: async () => { throw new Error("kv unavailable"); },
     } as KVNamespace;
 
-    const events = await loadGithubEvents(kv);
+    const payload = await loadGithubEvents(kv);
 
-    expect(events).toEqual([
-      {
-        type: "PUSH",
-        repo: "clanka-api",
-        message: "fresh message",
-        timestamp: "2026-03-01T00:00:00.000Z",
-      },
-    ]);
+    expect(payload).toEqual({
+      events: [
+        {
+          type: "PUSH",
+          repo: "clanka-api",
+          message: "fresh message",
+          timestamp: "2026-03-01T00:00:00.000Z",
+        },
+      ],
+      available: true,
+    });
   });
 
   it("normalizes repo names by removing clankamode/ prefix", async () => {
@@ -108,7 +119,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events).toHaveLength(1);
     expect(events[0].repo).toBe("clanka-api");
@@ -126,7 +137,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events).toHaveLength(1);
     expect(events[0].message.length).toBeLessThanOrEqual(100);
@@ -145,7 +156,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events[0]).toEqual({
       type: "PUSH",
@@ -168,7 +179,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events[0]).toEqual(expect.objectContaining({
       type: "PR",
@@ -189,7 +200,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events[0]).toEqual(expect.objectContaining({
       type: "ISSUE",
@@ -210,7 +221,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events[0]).toEqual(expect.objectContaining({
       type: "CREATE",
@@ -234,7 +245,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events).toHaveLength(1);
     expect(events[0].type).toBe("PUSH");
@@ -249,7 +260,7 @@ describe("loadGithubEvents", () => {
     }));
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify(raw), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events).toHaveLength(15);
     expect(events[0].message).toBe("commit-0");
@@ -266,7 +277,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events).toHaveLength(1);
     expect(events[0].message).toBe("push");
@@ -282,7 +293,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events).toHaveLength(1);
     expect(events[0].repo).toBe("otherorg/external-repo");
@@ -301,7 +312,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events[0].message.length).toBeLessThanOrEqual(100);
     expect(events[0].message.endsWith("...")).toBe(true);
@@ -321,7 +332,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events[0].message.length).toBeLessThanOrEqual(100);
     expect(events[0].message.endsWith("...")).toBe(true);
@@ -341,7 +352,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(createMockKV());
+    const { events } = await loadGithubEvents(createMockKV());
 
     expect(events[0].message.length).toBeLessThanOrEqual(100);
     expect(events[0].message.endsWith("...")).toBe(true);
@@ -362,7 +373,7 @@ describe("loadGithubEvents", () => {
       },
     ]), { status: 200 }));
 
-    const events = await loadGithubEvents(kv);
+    const { events } = await loadGithubEvents(kv);
 
     expect(events).toHaveLength(1);
     expect(putSpy).toHaveBeenCalledWith(

--- a/src/github.ts
+++ b/src/github.ts
@@ -10,7 +10,15 @@ import {
   GITHUB_STATS_CACHE_KEY,
   GITHUB_STATS_TTL_SEC,
 } from "./config";
-import type { ChangelogEntry, Env, GithubEvent, GithubStatsPayload, PostsCountPayload } from "./types";
+import type {
+  ChangelogEntry,
+  ChangelogPayload,
+  Env,
+  GithubEvent,
+  GithubEventsPayload,
+  GithubStatsPayload,
+  PostsCountPayload,
+} from "./types";
 
 const POST_HTML_RE = /^(\d{4}-\d{2}-\d{2})-(.+)\.html$/;
 
@@ -179,9 +187,19 @@ function parseChangelogEntries(raw: string | null): ChangelogEntry[] | null {
   }
 }
 
-export async function loadChangelog(env: Env): Promise<ChangelogEntry[]> {
+function unavailableChangelog(error: string): ChangelogPayload {
+  return {
+    commits: [],
+    available: false,
+    error,
+  };
+}
+
+export async function loadChangelog(env: Env): Promise<ChangelogPayload> {
   const cached = parseChangelogEntries(await env.CLANKA_STATE.get(CHANGELOG_CACHE_KEY));
-  if (cached !== null) return cached;
+  if (cached !== null) {
+    return { commits: cached, available: true };
+  }
 
   const headers: Record<string, string> = {
     "User-Agent": "clanka-api/1.0",
@@ -189,21 +207,25 @@ export async function loadChangelog(env: Env): Promise<ChangelogEntry[]> {
   };
   if (env.GITHUB_TOKEN) headers["Authorization"] = `Bearer ${env.GITHUB_TOKEN}`;
 
-  const res = await fetch(CHANGELOG_URL, { headers });
-  if (!res.ok) return [];
+  try {
+    const res = await fetch(CHANGELOG_URL, { headers });
+    if (!res.ok) return unavailableChangelog("github_unavailable");
 
-  const body = await res.json() as unknown;
-  if (!Array.isArray(body)) return [];
+    const body = await res.json() as unknown;
+    if (!Array.isArray(body)) return unavailableChangelog("github_unavailable");
 
-  const payload = body
-    .slice(0, 10)
-    .map((entry) => normalizeChangelogEntry(entry))
-    .filter((entry): entry is ChangelogEntry => Boolean(entry));
+    const commits = body
+      .slice(0, 10)
+      .map((entry) => normalizeChangelogEntry(entry))
+      .filter((entry): entry is ChangelogEntry => Boolean(entry));
 
-  await env.CLANKA_STATE.put(CHANGELOG_CACHE_KEY, JSON.stringify(payload), {
-    expirationTtl: CHANGELOG_TTL_SEC,
-  });
-  return payload;
+    await env.CLANKA_STATE.put(CHANGELOG_CACHE_KEY, JSON.stringify(commits), {
+      expirationTtl: CHANGELOG_TTL_SEC,
+    });
+    return { commits, available: true };
+  } catch {
+    return unavailableChangelog("github_unavailable");
+  }
 }
 
 export async function loadGithubStats(env: Env): Promise<GithubStatsPayload> {
@@ -309,19 +331,34 @@ function truncateMessage(message: string, maxLen = MESSAGE_MAX_LEN): string {
   return `${message.slice(0, maxLen - 3)}...`;
 }
 
-export async function loadGithubEvents(kv: KVNamespace): Promise<GithubEvent[]> {
+function unavailableEvents(error: string): GithubEventsPayload {
+  return {
+    events: [],
+    available: false,
+    error,
+  };
+}
+
+export async function loadGithubEvents(kv: KVNamespace): Promise<GithubEventsPayload> {
   const cached = await kv.get(GITHUB_EVENTS_CACHE_KEY);
   if (cached) {
-    try { return JSON.parse(cached) as GithubEvent[]; } catch { /* fall through */ }
+    try {
+      const events = JSON.parse(cached) as GithubEvent[];
+      if (Array.isArray(events)) {
+        return { events, available: true };
+      }
+    } catch { /* fall through */ }
   }
 
   try {
     const res = await fetch("https://api.github.com/users/clankamode/events?per_page=30", {
       headers: { "User-Agent": "clanka-api/1.0", "Accept": "application/vnd.github.v3+json" },
     });
-    if (!res.ok) return [];
+    if (!res.ok) return unavailableEvents("github_unavailable");
 
     const raw = (await res.json()) as GhEvent[];
+    if (!Array.isArray(raw)) return unavailableEvents("github_unavailable");
+
     const allowed = new Set(["PushEvent", "CreateEvent", "PullRequestEvent", "IssuesEvent"]);
     const events: GithubEvent[] = [];
 
@@ -357,8 +394,8 @@ export async function loadGithubEvents(kv: KVNamespace): Promise<GithubEvent[]> 
     } catch {
       // ignore cache write failures and still serve fresh data
     }
-    return events;
+    return { events, available: true };
   } catch {
-    return [];
+    return unavailableEvents("github_unavailable");
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -580,7 +580,7 @@ describe("Malformed cache fallbacks", () => {
     expect(Number.isNaN(Date.parse(body.cachedAt))).toBe(false);
   });
 
-  it("returns { events: [] } when github:events:v1 cache JSON is malformed", async () => {
+  it("marks events unavailable when github:events:v1 cache JSON is malformed and GitHub fails", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
 
     const res = await worker.fetch(
@@ -590,7 +590,11 @@ describe("Malformed cache fallbacks", () => {
     const body = await json(res);
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({ events: [] });
+    expect(body).toEqual({
+      events: [],
+      available: false,
+      error: "github_unavailable",
+    });
   });
 });
 
@@ -752,18 +756,49 @@ describe("GET /github/events", () => {
     const body = await json(res);
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({ events: cached });
+    expect(body).toEqual({ events: cached, available: true });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("returns an empty events array when GitHub fetch throws", async () => {
+  it("marks events unavailable instead of looking empty when GitHub fetch throws", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
 
     const res = await worker.fetch(req("/github/events"), createEnv());
     const body = await json(res);
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({ events: [] });
+    expect(body).toEqual({
+      events: [],
+      available: false,
+      error: "github_unavailable",
+    });
+  });
+
+  it("marks events unavailable when GitHub returns a non-ok status", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
+
+    const res = await worker.fetch(req("/github/events"), createEnv());
+    const body = await json(res);
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      events: [],
+      available: false,
+      error: "github_unavailable",
+    });
+  });
+
+  it("marks a genuine empty feed as available", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+
+    const res = await worker.fetch(req("/github/events"), createEnv());
+    const body = await json(res);
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      events: [],
+      available: true,
+    });
   });
 
   it("rejects non-GET with 405", async () => {
@@ -916,8 +951,10 @@ describe("GET /changelog", () => {
     expect(res.status).toBe(200);
     expect(body).toEqual(expect.objectContaining({
       commits: expect.any(Array),
+      available: true,
       timestamp: expect.any(String),
     }));
+    expect(body).not.toHaveProperty("error");
     expect(body.commits[0]).toEqual(expect.objectContaining({
       sha: "abc123",
       message: "feat: add pipeline",
@@ -1003,20 +1040,37 @@ describe("GET /changelog", () => {
     expect(res.status).toBe(200);
     expect(body).toEqual(expect.objectContaining({
       commits: [],
+      available: false,
       error: "no token",
       timestamp: expect.any(String),
     }));
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("returns empty commits when GitHub request fails", async () => {
+  it("marks changelog unavailable instead of looking empty when GitHub request fails", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
     const res = await worker.fetch(req("/changelog"), createEnv({}, { GITHUB_TOKEN: "gh-token" }));
     const body = await json(res);
     expect(res.status).toBe(200);
-    expect(body.commits).toEqual([]);
+    expect(body).toEqual(expect.objectContaining({
+      commits: [],
+      available: false,
+      error: "github_unavailable",
+      timestamp: expect.any(String),
+    }));
+  });
+
+  it("marks a genuine empty changelog as available", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+    const res = await worker.fetch(req("/changelog"), createEnv({}, { GITHUB_TOKEN: "gh-token" }));
+    const body = await json(res);
+    expect(res.status).toBe(200);
+    expect(body).toEqual(expect.objectContaining({
+      commits: [],
+      available: true,
+      timestamp: expect.any(String),
+    }));
     expect(body).not.toHaveProperty("error");
-    expect(body).toHaveProperty("timestamp");
   });
 
   it("limits changelog response to 10 commits", async () => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -807,8 +807,8 @@ export async function handleFetch(
       if (request.method !== "GET") {
         return respond(JSON.stringify({ error: "Method Not Allowed" }), { status: 405, headers: corsHeaders });
       }
-      const events = await loadGithubEvents(env.CLANKA_STATE);
-      return respond(JSON.stringify({ events }), { headers: corsHeaders });
+      const eventsPayload = await loadGithubEvents(env.CLANKA_STATE);
+      return respond(JSON.stringify(eventsPayload), { headers: corsHeaders });
     }
 
     if (url.pathname === "/changelog") {
@@ -823,14 +823,17 @@ export async function handleFetch(
       if (!token) {
         return respond(JSON.stringify({
           commits: [],
+          available: false,
           error: "no token",
           timestamp: new Date().toISOString(),
         }), { headers: corsHeaders });
       }
 
-      const commits = await loadChangelog(env);
+      const changelog = await loadChangelog(env);
       return respond(JSON.stringify({
-        commits,
+        commits: changelog.commits,
+        available: changelog.available !== false,
+        ...(changelog.error ? { error: changelog.error } : {}),
         timestamp: new Date().toISOString(),
       }), { headers: corsHeaders });
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,13 @@ export type ChangelogEntry = {
   date: string;
 };
 
+export type ChangelogPayload = {
+  commits: ChangelogEntry[];
+  /** False when the payload is a failure placeholder, not a real empty changelog. */
+  available?: boolean;
+  error?: string;
+};
+
 export type RegistryEntry = {
   repo: string;
   criticality: FleetCriticality;
@@ -105,6 +112,13 @@ export type GithubEvent = {
   repo: string;
   message: string;
   timestamp: string;
+};
+
+export type GithubEventsPayload = {
+  events: GithubEvent[];
+  /** False when the payload is a failure placeholder, not a real empty feed. */
+  available?: boolean;
+  error?: string;
 };
 
 export type PostsCountPayload = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent
Second product-honesty pass leftover after #61–#65: stop empty-looking success payloads when GitHub is down for the remaining public GitHub read paths.

## Problem
- `GET /changelog` (with token) returned `{ commits: [] }` on fetch failure — indistinguishable from a real empty history. Missing-token already had `error: "no token"`.
- `GET /github/events` returned `{ events: [] }` on network/API failure — looked like “no activity”.
- OpenAPI still summarized `/projects` as “active projects” after #64 changed status to `registered`.

## Change
- `/changelog` and `/github/events` now emit `available: false` + `error: "github_unavailable"` on failure.
- Genuine empty feeds/changelogs stay `available: true`.
- README + OpenAPI wording aligned.
- Tests strengthened (not weakened); suite at 211 passing.

## Out of scope (checked, not inventing PRs)
- First-pass #61–#65 left intact.
- `/projects` `cached: true` hardcode and `/tasks` empty-on-miss remain deferred (different shape / lower confidence).
- No Dependabot / CI gate changes.

## Test plan
- [x] `npm test` (211 passing)
- [ ] Force GitHub 502 on `/changelog` and `/github/events` → `available: false`
- [ ] Successful empty array responses → `available: true`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fa272de-2edc-430d-99e8-457d20c83b71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fa272de-2edc-430d-99e8-457d20c83b71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

